### PR TITLE
Distinguish between ordered and unordered sets

### DIFF
--- a/sets/ordered_set.go
+++ b/sets/ordered_set.go
@@ -13,65 +13,35 @@ import (
 type OrderedSet[T constraints.Ordered] map[T]struct{}
 
 func NewOrderedSet[T constraints.Ordered](vs ...T) OrderedSet[T] {
-	s := make(OrderedSet[T], len(vs))
-	for _, v := range vs {
-		s.Insert(v)
-	}
-	return s
+	return OrderedSet[T](NewSet[T](vs...))
 }
 
 func (s OrderedSet[T]) Contains(v T) bool {
-	return s.ContainsAny(v)
+	return Set[T](s).Contains(v)
 }
 
 func (s OrderedSet[T]) ContainsAny(vs ...T) bool {
-	for _, v := range vs {
-		_, exists := s[v]
-		if exists {
-			return true
-		}
-	}
-	return false
+	return Set[T](s).ContainsAny(vs...)
 }
 
 func (s OrderedSet[T]) ContainsAll(vs ...T) bool {
-	for _, v := range vs {
-		_, exists := s[v]
-		if !exists {
-			return false
-		}
-	}
-	return true
+	return Set[T](s).ContainsAll(vs...)
 }
 
 func (s OrderedSet[T]) Insert(vs ...T) {
-	for _, v := range vs {
-		s[v] = struct{}{}
-	}
+	Set[T](s).Insert(vs...)
 }
 
 func (s OrderedSet[T]) Delete(vs ...T) {
-	for _, v := range vs {
-		delete(s, v)
-	}
+	Set[T](s).Delete(vs...)
 }
 
 func (s OrderedSet[T]) Union(other OrderedSet[T]) {
-	for k := range other {
-		s.Insert(k)
-	}
+	Set[T](s).Union(Set[T](other))
 }
 
 func (s OrderedSet[T]) Intersect(other OrderedSet[T]) {
-	var toDelete []T
-	for k := range s {
-		if _, exists := other[k]; !exists {
-			toDelete = append(toDelete, k)
-		}
-	}
-	for _, k := range toDelete {
-		delete(s, k)
-	}
+	Set[T](s).Intersect(Set[T](other))
 }
 
 // Marshals as a sorted slice.

--- a/sets/ordered_set.go
+++ b/sets/ordered_set.go
@@ -5,24 +5,26 @@ import (
 	"sort"
 
 	"github.com/pkg/errors"
+	"golang.org/x/exp/constraints"
 	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 )
 
-type Set[T comparable] map[T]struct{}
+type OrderedSet[T constraints.Ordered] map[T]struct{}
 
-func NewSet[T comparable](vs ...T) Set[T] {
-	s := make(Set[T], len(vs))
+func NewOrderedSet[T constraints.Ordered](vs ...T) OrderedSet[T] {
+	s := make(OrderedSet[T], len(vs))
 	for _, v := range vs {
 		s.Insert(v)
 	}
 	return s
 }
 
-func (s Set[T]) Contains(v T) bool {
+func (s OrderedSet[T]) Contains(v T) bool {
 	return s.ContainsAny(v)
 }
 
-func (s Set[T]) ContainsAny(vs ...T) bool {
+func (s OrderedSet[T]) ContainsAny(vs ...T) bool {
 	for _, v := range vs {
 		_, exists := s[v]
 		if exists {
@@ -32,7 +34,7 @@ func (s Set[T]) ContainsAny(vs ...T) bool {
 	return false
 }
 
-func (s Set[T]) ContainsAll(vs ...T) bool {
+func (s OrderedSet[T]) ContainsAll(vs ...T) bool {
 	for _, v := range vs {
 		_, exists := s[v]
 		if !exists {
@@ -42,25 +44,25 @@ func (s Set[T]) ContainsAll(vs ...T) bool {
 	return true
 }
 
-func (s Set[T]) Insert(vs ...T) {
+func (s OrderedSet[T]) Insert(vs ...T) {
 	for _, v := range vs {
 		s[v] = struct{}{}
 	}
 }
 
-func (s Set[T]) Delete(vs ...T) {
+func (s OrderedSet[T]) Delete(vs ...T) {
 	for _, v := range vs {
 		delete(s, v)
 	}
 }
 
-func (s Set[T]) Union(other Set[T]) {
+func (s OrderedSet[T]) Union(other OrderedSet[T]) {
 	for k := range other {
 		s.Insert(k)
 	}
 }
 
-func (s Set[T]) Intersect(other Set[T]) {
+func (s OrderedSet[T]) Intersect(other OrderedSet[T]) {
 	var toDelete []T
 	for k := range s {
 		if _, exists := other[k]; !exists {
@@ -72,39 +74,41 @@ func (s Set[T]) Intersect(other Set[T]) {
 	}
 }
 
-func (s Set[T]) MarshalJSON() ([]byte, error) {
+// Marshals as a sorted slice.
+func (s OrderedSet[T]) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.AsSlice())
 }
 
-func (s *Set[T]) UnmarshalJSON(text []byte) error {
+func (s *OrderedSet[T]) UnmarshalJSON(text []byte) error {
 	var slice []T
 	if err := json.Unmarshal(text, &slice); err != nil {
 		return errors.Wrapf(err, "failed to unmarshal stringset")
 	}
-	*s = make(Set[T], len(slice))
+	*s = make(OrderedSet[T], len(slice))
 	for _, elt := range slice {
 		(*s)[elt] = struct{}{}
 	}
 	return nil
 }
 
-func (s Set[T]) Clone() Set[T] {
+func (s OrderedSet[T]) Clone() OrderedSet[T] {
 	return maps.Clone(s)
 }
 
-// AsSlice returns the set as a slice in a nondeterministic order.
-func (s Set[T]) AsSlice() []T {
+// AsSlice returns the set as a sorted slice.
+func (s OrderedSet[T]) AsSlice() []T {
 	rv := make([]T, 0, len(s))
 	for x, _ := range s {
 		rv = append(rv, x)
 	}
+	slices.Sort(rv)
 	return rv
 }
 
 // Creates a new set from the intersection of sets.
-func Intersect[T comparable](sets ...Set[T]) Set[T] {
+func IntersectOrdered[T constraints.Ordered](sets ...OrderedSet[T]) OrderedSet[T] {
 	if len(sets) == 0 {
-		return Set[T]{}
+		return OrderedSet[T]{}
 	}
 
 	// Sort by set length.  Starting with the smallest set reduces

--- a/sets/ordered_set_test.go
+++ b/sets/ordered_set_test.go
@@ -1,0 +1,78 @@
+package sets
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasicOperations(t *testing.T) {
+	s := NewOrderedSet[int]()
+	assert.Equal(t, len(s), 0)
+	assert.Equal(t, map[int]struct{}(s), map[int]struct{}{})
+
+	s.Insert(1)
+	assert.Equal(t, s, NewOrderedSet(1))
+
+	s.Intersect(NewOrderedSet(1, 2))
+	assert.Equal(t, s, NewOrderedSet(1))
+
+	s.Union(NewOrderedSet(1, 2))
+	assert.Equal(t, s, NewOrderedSet(1, 2))
+
+	s.Delete(1)
+	assert.Equal(t, s, NewOrderedSet(2))
+}
+
+func TestOrderedSetJson(t *testing.T) {
+	s := NewOrderedSet[int](3, 2, 1)
+
+	bs, err := json.Marshal(s)
+	assert.NoError(t, err)
+
+	var deserialized OrderedSet[int]
+	err = json.Unmarshal(bs, &deserialized)
+	assert.NoError(t, err)
+
+	assert.Equal(t, deserialized, s, "s == unmarshal(marshal(s))")
+}
+
+func TestJsonOrdering(t *testing.T) {
+	bs1, err := json.Marshal(NewOrderedSet(1, 2, 3))
+	assert.NoError(t, err)
+
+	bs2, err := json.Marshal(NewOrderedSet(3, 2, 1))
+	assert.NoError(t, err)
+
+	assert.Equal(t, string(bs1), string(bs2), "marshal(s) == marshal(s)")
+}
+
+func TestOrderedSetIntersect(t *testing.T) {
+	testCases := []struct {
+		name     string
+		sets     []OrderedSet[int]
+		expected OrderedSet[int]
+	}{
+		{
+			name:     "empty",
+			sets:     nil,
+			expected: NewOrderedSet[int](),
+		},
+		{
+			name:     "overlap",
+			sets:     []OrderedSet[int]{NewOrderedSet(1, 2), NewOrderedSet(2, 3)},
+			expected: NewOrderedSet(2),
+		},
+		{
+			name:     "no overlap",
+			sets:     []OrderedSet[int]{NewOrderedSet(1, 2), NewOrderedSet(3, 4)},
+			expected: NewOrderedSet[int](),
+		},
+	}
+
+	for _, tc := range testCases {
+		intersected := IntersectOrdered(tc.sets...)
+		assert.Equal(t, tc.expected, intersected, tc.name)
+	}
+}

--- a/sets/set_test.go
+++ b/sets/set_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBasicOperations(t *testing.T) {
+func TestBasicSetOperations(t *testing.T) {
 	s := NewSet[int]()
 	assert.Equal(t, len(s), 0)
 	assert.Equal(t, map[int]struct{}(s), map[int]struct{}{})
@@ -25,7 +25,7 @@ func TestBasicOperations(t *testing.T) {
 	assert.Equal(t, s, NewSet(2))
 }
 
-func TestJson(t *testing.T) {
+func TestSetJson(t *testing.T) {
 	s := NewSet[int](3, 2, 1)
 
 	bs, err := json.Marshal(s)
@@ -38,12 +38,31 @@ func TestJson(t *testing.T) {
 	assert.Equal(t, deserialized, s, "s == unmarshal(marshal(s))")
 }
 
-func TestJsonOrdering(t *testing.T) {
-	bs1, err := json.Marshal(NewSet(1, 2, 3))
-	assert.NoError(t, err)
+func TestSetIntersect(t *testing.T) {
+	testCases := []struct {
+		name     string
+		sets     []Set[int]
+		expected Set[int]
+	}{
+		{
+			name:     "empty",
+			sets:     nil,
+			expected: NewSet[int](),
+		},
+		{
+			name:     "overlap",
+			sets:     []Set[int]{NewSet(1, 2), NewSet(2, 3)},
+			expected: NewSet(2),
+		},
+		{
+			name:     "no overlap",
+			sets:     []Set[int]{NewSet(1, 2), NewSet(3, 4)},
+			expected: NewSet[int](),
+		},
+	}
 
-	bs2, err := json.Marshal(NewSet(3, 2, 1))
-	assert.NoError(t, err)
-
-	assert.Equal(t, string(bs1), string(bs2), "marshal(s) == marshal(s)")
+	for _, tc := range testCases {
+		intersected := Intersect(tc.sets...)
+		assert.Equal(t, tc.expected, intersected, tc.name)
+	}
 }


### PR DESCRIPTION
Relaxes the type constraint on Set to be comparable rather than
constraints.Ordered, and introduces a new OrderedSet type.

The immediate practical difference is that OrderedSet supports stable JSON
serialization by producing a sorted list, whereas Set may produce a different
ordering in each serialization.