### PR TITLE
More tweaks to maps

### DIFF
--- a/maps/complex_key_map.go
+++ b/maps/complex_key_map.go
@@ -40,6 +40,12 @@ func (m ComplexKeyMap[K, V]) GetOrComputeNoError(k K, computeValue func() V) V {
 }
 
 // Returns the value associated with the given key k. If the key does not
+// already exist in the map, the default Go value is returned.
+func (m ComplexKeyMap[K, V]) GetOrDefault(k K) V {
+	return Map[K, V](m).GetOrDefault(k)
+}
+
+// Returns the value associated with the given key k. If the key does not
 // already exist in the map, the supplied value is entered into the map and
 // returned.
 func (m ComplexKeyMap[K, V]) GetOrValue(k K, value V) V {

--- a/maps/complex_key_map.go
+++ b/maps/complex_key_map.go
@@ -40,10 +40,10 @@ func (m ComplexKeyMap[K, V]) GetOrComputeNoError(k K, computeValue func() V) V {
 }
 
 // Returns the value associated with the given key k. If the key does not
-// already exist in the map, the supplied default value is entered into the map
-// and returned.
-func (m ComplexKeyMap[K, V]) GetOrDefault(k K, defaultValue V) V {
-	return Map[K, V](m).GetOrDefault(k, defaultValue)
+// already exist in the map, the supplied value is entered into the map and
+// returned.
+func (m ComplexKeyMap[K, V]) GetOrValue(k K, value V) V {
+	return Map[K, V](m).GetOrValue(k, value)
 }
 
 func (m ComplexKeyMap[K, V]) ContainsKey(k K) bool {

--- a/maps/complex_key_map.go
+++ b/maps/complex_key_map.go
@@ -12,82 +12,50 @@ import (
 type ComplexKeyMap[K comparable, V any] map[K]V
 
 func (m ComplexKeyMap[K, V]) Put(k K, v V) {
-	m[k] = v
+	Map[K, V](m).Put(k, v)
 }
 
 func (m ComplexKeyMap[K, V]) Upsert(k K, v V, onConflict func(v, newV V) V) {
-	newV := v
-	if oldV, exists := m[k]; exists {
-		newV = onConflict(oldV, newV)
-	}
-	m[k] = newV
+	Map[K, V](m).Upsert(k, v, onConflict)
 }
 
 func (m ComplexKeyMap[K, V]) Add(other ComplexKeyMap[K, V], onConflict func(v, newV V) V) {
-	for k, v := range other {
-		m.Upsert(k, v, onConflict)
-	}
+	Map[K, V](m).Add(Map[K, V](other), onConflict)
 }
 
 func (m ComplexKeyMap[K, V]) Get(k K) optionals.Optional[V] {
-	v, exists := m[k]
-	if exists {
-		return optionals.Some(v)
-	}
-	return optionals.None[V]()
+	return Map[K, V](m).Get(k)
 }
 
 // Returns the value associated with the given key k. If the key does not
 // already exist in the map, the supplied function is called, and the resulting
 // value is entered into the map and returned.
 func (m ComplexKeyMap[K, V]) GetOrCompute(k K, computeValue func() (V, error)) (V, error) {
-	if v, exists := m[k]; exists {
-		return v, nil
-	}
-
-	v, err := computeValue()
-	if err != nil {
-		return v, err
-	}
-
-	m[k] = v
-	return v, nil
+	return Map[K, V](m).GetOrCompute(k, computeValue)
 }
 
 // A version of GetOrCompute that is guaranteed to not error.
 func (m ComplexKeyMap[K, V]) GetOrComputeNoError(k K, computeValue func() V) V {
-	if v, exists := m[k]; exists {
-		return v
-	}
-
-	v := computeValue()
-	m[k] = v
-	return v
+	return Map[K, V](m).GetOrComputeNoError(k, computeValue)
 }
 
 // Returns the value associated with the given key k. If the key does not
 // already exist in the map, the supplied default value is entered into the map
 // and returned.
 func (m ComplexKeyMap[K, V]) GetOrDefault(k K, defaultValue V) V {
-	v, exists := m[k]
-	if !exists {
-		v = defaultValue
-		m[k] = v
-	}
-	return v
+	return Map[K, V](m).GetOrDefault(k, defaultValue)
 }
 
 func (m ComplexKeyMap[K, V]) ContainsKey(k K) bool {
-	_, exists := m[k]
-	return exists
+	return Map[K, V](m).ContainsKey(k)
 }
 
 func (m ComplexKeyMap[K, V]) Delete(k K) {
-	delete(m, k)
+	Map[K, V](m).Delete(k)
 }
 
 func (m ComplexKeyMap[K, V]) IsEmpty() bool {
-	return len(m) == 0
+	return Map[K, V](m).IsEmpty()
 }
 
 type SliceElt[K comparable, V any] struct {

--- a/maps/complex_key_map_test.go
+++ b/maps/complex_key_map_test.go
@@ -30,9 +30,9 @@ func TestBasicComplexKeyMapOperations(t *testing.T) {
 	m.Put(foo, 42)
 	assert.Equal(t, ComplexKeyMap[[2]string, int]{foo: 42, bar: 1}, m)
 	assert.Equal(t, m.Get(foo), optionals.Some(42))
-	assert.Equal(t, m.GetOrDefault(foo, 19), 42)
+	assert.Equal(t, m.GetOrValue(foo, 19), 42)
 	assert.False(t, m.ContainsKey(baz))
-	assert.Equal(t, m.GetOrDefault(baz, 19), 19)
+	assert.Equal(t, m.GetOrValue(baz, 19), 19)
 	assert.True(t, m.ContainsKey(baz))
 	assert.Equal(t, m.Get(baz), optionals.Some(19))
 

--- a/maps/map.go
+++ b/maps/map.go
@@ -59,12 +59,12 @@ func (m Map[K, V]) GetOrComputeNoError(k K, computeValue func() V) V {
 }
 
 // Returns the value associated with the given key k. If the key does not
-// already exist in the map, the supplied default value is entered into the map
-// and returned.
-func (m Map[K, V]) GetOrDefault(k K, defaultValue V) V {
+// already exist in the map, the supplied value is entered into the map and
+// returned.
+func (m Map[K, V]) GetOrValue(k K, value V) V {
 	v, exists := m[k]
 	if !exists {
-		v = defaultValue
+		v = value
 		m[k] = v
 	}
 	return v

--- a/maps/map.go
+++ b/maps/map.go
@@ -4,6 +4,10 @@ import "github.com/akitasoftware/go-utils/optionals"
 
 type Map[K comparable, V any] map[K]V
 
+func (m Map[K, V]) Put(k K, v V) {
+	m[k] = v
+}
+
 func (m Map[K, V]) Upsert(k K, v V, onConflict func(v, newV V) V) {
 	newV := v
 	if oldV, exists := m[k]; exists {
@@ -24,4 +28,57 @@ func (m Map[K, V]) Get(k K) optionals.Optional[V] {
 		return optionals.Some(v)
 	}
 	return optionals.None[V]()
+}
+
+// Returns the value associated with the given key k. If the key does not
+// already exist in the map, the supplied function is called, and the resulting
+// value is entered into the map and returned.
+func (m Map[K, V]) GetOrCompute(k K, computeValue func() (V, error)) (V, error) {
+	if v, exists := m[k]; exists {
+		return v, nil
+	}
+
+	v, err := computeValue()
+	if err != nil {
+		return v, err
+	}
+
+	m[k] = v
+	return v, nil
+}
+
+// A version of GetOrCompute that is guaranteed to not error.
+func (m Map[K, V]) GetOrComputeNoError(k K, computeValue func() V) V {
+	if v, exists := m[k]; exists {
+		return v
+	}
+
+	v := computeValue()
+	m[k] = v
+	return v
+}
+
+// Returns the value associated with the given key k. If the key does not
+// already exist in the map, the supplied default value is entered into the map
+// and returned.
+func (m Map[K, V]) GetOrDefault(k K, defaultValue V) V {
+	v, exists := m[k]
+	if !exists {
+		v = defaultValue
+		m[k] = v
+	}
+	return v
+}
+
+func (m Map[K, V]) ContainsKey(k K) bool {
+	_, exists := m[k]
+	return exists
+}
+
+func (m Map[K, V]) Delete(k K) {
+	delete(m, k)
+}
+
+func (m Map[K, V]) IsEmpty() bool {
+	return len(m) == 0
 }

--- a/maps/map.go
+++ b/maps/map.go
@@ -59,6 +59,12 @@ func (m Map[K, V]) GetOrComputeNoError(k K, computeValue func() V) V {
 }
 
 // Returns the value associated with the given key k. If the key does not
+// already exist in the map, the default Go value is returned.
+func (m Map[K, V]) GetOrDefault(k K) V {
+	return m[k]
+}
+
+// Returns the value associated with the given key k. If the key does not
 // already exist in the map, the supplied value is entered into the map and
 // returned.
 func (m Map[K, V]) GetOrValue(k K, value V) V {


### PR DESCRIPTION
Filled out `Map` to match `ComplexKeyMap`. Implementations in `ComplexKeyMap` now delegate to `Map`.

Renamed `GetOrDefault` → `GetOrValue`. Added `GetOrDefault` to correspond to `m[k]`.