### PR TITLE
Implement JSON serialization/deserialization for Optional[T]

### DIFF
--- a/optionals/optional.go
+++ b/optionals/optional.go
@@ -1,5 +1,11 @@
 package optionals
 
+import "encoding/json"
+
+// An Optional[T] is an option type.
+//
+// The JSON serialization/deserialization of an Optional[T] is compatible with
+// that of a *T.
 type Optional[T any] struct {
 	value *T
 }
@@ -71,4 +77,12 @@ func Map[T, U any](opt Optional[T], f func(T) U) Optional[U] {
 	}
 
 	return Some(f(*opt.value))
+}
+
+func (opt Optional[T]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(opt.value)
+}
+
+func (opt *Optional[T]) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &opt.value)
 }

--- a/optionals/optional_test.go
+++ b/optionals/optional_test.go
@@ -1,0 +1,43 @@
+package optionals
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoneJSON(t *testing.T) {
+	// Test that None and nil serialize to the same thing.
+	none := None[int]()
+	null := (*int)(nil)
+	noneJSON, err := json.Marshal(none)
+	assert.NoError(t, err)
+	nullJSON, err := json.Marshal(null)
+	assert.NoError(t, err)
+	assert.Equal(t, nullJSON, noneJSON)
+
+	// Test that deserialize(serialize(None)) == None.
+	var deserialized Optional[int]
+	err = json.Unmarshal(noneJSON, &deserialized)
+	assert.NoError(t, err)
+	assert.Equal(t, none, deserialized)
+}
+
+func TestSomeJSON(t *testing.T) {
+	// Test that Some(42) and 42 serialize to the same thing.
+	v := 42
+	someV := Some(v)
+	pV := &v
+	someVJSON, err := json.Marshal(someV)
+	assert.NoError(t, err)
+	pVJSON, err := json.Marshal(pV)
+	assert.NoError(t, err)
+	assert.Equal(t, pVJSON, someVJSON)
+
+	// Test that deserialize(serialize(Some(42))) == Some(42).
+	var deserialized Optional[int]
+	err = json.Unmarshal(someVJSON, &deserialized)
+	assert.NoError(t, err)
+	assert.Equal(t, someV, deserialized)
+}


### PR DESCRIPTION
The JSON representation of an `Optional[T]` is the same as that of the equivalent `*T`.