### PR TITLE
Additional methods for creating Sets.

### DIFF
--- a/sets/set.go
+++ b/sets/set.go
@@ -20,6 +20,28 @@ func NewSet[T comparable](vs ...T) Set[T] {
 	return s
 }
 
+// Create a set from a slice, applying a mapping function first to
+// translate to a comparable type.
+func FromSlice[T1 any, T2 comparable](vs []T1, f func(T1) T2) Set[T2] {
+	s := make(Set[T2], len(vs))
+	for _, v := range vs {
+		s.Insert(f(v))
+	}
+	return s
+}
+
+// Applies f to each element of the slice in order, removes any None results,
+// and converts the Some results to a Set.
+func FromFilteredSlice[T1 any, T2 comparable](vs []T1, f func(T1) optionals.Optional[T2]) Set[T2] {
+	s := make(Set[T2], len(vs))
+	for _, v := range vs {
+		if u, exists := f(v).Get(); exists {
+			s.Insert(u)
+		}
+	}
+	return s
+}
+
 func (s Set[T]) Equals(other Set[T]) bool {
 	if len(s) != len(other) {
 		return false

--- a/sets/set_test.go
+++ b/sets/set_test.go
@@ -2,8 +2,10 @@ package sets
 
 import (
 	"encoding/json"
+	"strconv"
 	"testing"
 
+	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -65,4 +67,30 @@ func TestSetIntersect(t *testing.T) {
 		intersected := Intersect(tc.sets...)
 		assert.Equal(t, tc.expected, intersected, tc.name)
 	}
+}
+
+func TestSetFromSlice(t *testing.T) {
+	slice := []string{"0x1", "0x2", "0x3", "0xf", "xyz"}
+
+	e1 := NewSet[int](0, 1, 2, 3, 15)
+	s1 := FromSlice(slice, func(s string) int {
+		v, err := strconv.ParseInt(s, 0, 0)
+		if err != nil {
+			return 0
+		} else {
+			return int(v)
+		}
+	})
+	assert.Equal(t, e1, s1)
+
+	e2 := NewSet[int](1, 2, 3)
+	s2 := FromFilteredSlice(slice, func(s string) optionals.Optional[int] {
+		v, err := strconv.ParseInt(s, 0, 0)
+		if err != nil || v > 10 {
+			return optionals.None[int]()
+		} else {
+			return optionals.Some(int(v))
+		}
+	})
+	assert.Equal(t, e2, s2)
 }


### PR DESCRIPTION
I have encountered a few cases where I want to create a Set from a slice of the wrong type. Writing the boilerplate to use slice.Map and then create the set is just as long (and twice as expensive) as a native loop. Hopefully having dedicated functions will make it a little more attractive to write these transformations in functional style.