### PR TITLE
[POA-477] Handle nil case of maps.Clone()

### DIFF
--- a/sets/ordered_set.go
+++ b/sets/ordered_set.go
@@ -74,7 +74,11 @@ func (s *OrderedSet[T]) UnmarshalJSON(text []byte) error {
 }
 
 func (s OrderedSet[T]) Clone() OrderedSet[T] {
-	return maps.Clone(s)
+	clonedMap := maps.Clone(s)
+	if clonedMap == nil {
+		clonedMap = NewOrderedSet[T]()
+	}
+	return clonedMap
 }
 
 // Returns the set as a sorted slice.

--- a/sets/set.go
+++ b/sets/set.go
@@ -126,7 +126,11 @@ func (s *Set[T]) UnmarshalJSON(text []byte) error {
 }
 
 func (s Set[T]) Clone() Set[T] {
-	return maps.Clone(s)
+	clonedMap := maps.Clone(s)
+	if clonedMap == nil {
+		clonedMap = NewSet[T]()
+	}
+	return clonedMap
 }
 
 // AsSlice returns the set as a slice in a nondeterministic order.


### PR DESCRIPTION
* In the newer versions of the `x/exp` package, it preserves the `nil` case of maps while cloning.
* Handled this case in Clone functions of `sets` and`orderedSets`
* Didn't updated the `x/exp` function here since, we don't know all the other breaking changes.